### PR TITLE
chore(npm_publish): Simply adding CD on this project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,16 @@ jobs:
 
 workflows:
   version: 2
-  lint-deploy:
+  lint:
     jobs:
       - lint
+
+  deploy:
+    jobs:
+      - lint:
+          filters:
+            tags:
+              only: /^v.*/
       - deploy:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,7 @@ workflows:
 
   deploy:
     jobs:
-      - lint:
-          filters:
-            tags:
-              only: /^v.*/
+      - lint
       - deploy:
           requires:
             - lint
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,15 @@ workflows:
 
   deploy:
     jobs:
-      - lint
+      - lint:
+          filters:
+            tags:
+              only: /^v.*/
       - deploy:
           requires:
             - lint
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,17 @@ workflows:
 
   deploy:
     jobs:
-      - lint
+      - lint:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - deploy:
           requires:
             - lint
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2.1
+
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/node:12.20
+
+jobs:
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run: yarn
+      - run:
+          name: Run linter
+          command: yarn lint
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish
+
+workflows:
+  version: 2
+  lint-deploy:
+    jobs:
+      - lint
+      - deploy:
+          requires:
+            - lint
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
       - deploy:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run:
-          name: Publish package
+          name: Publish package based on package.json version
           command: npm publish
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,17 +49,7 @@ workflows:
 
   deploy:
     jobs:
-      - lint:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+      - lint
       - deploy:
           requires:
             - lint
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tillersystems/eslint-config",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Shareable ESLint configuration used at Tiller Systems",
   "repository": "tillersystems/tiller-eslint-config ",
   "author": "Thomas Roux <troux@tillersystems.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tillersystems/eslint-config",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Shareable ESLint configuration used at Tiller Systems",
   "repository": "tillersystems/tiller-eslint-config ",
   "author": "Thomas Roux <troux@tillersystems.com>",


### PR DESCRIPTION
This CD process is actually based on the `v.x.x.x` (`/^v.*/`) commits to detect different Github releases.

Already tested without filters ✅ (Unpublished 1.2.6) [Here](https://app.circleci.com/pipelines/github/tillersystems/tiller-eslint-config/7/workflows/bd0d2e48-ce59-44df-9bd5-beab8775a8ae)

A simple release commit tag will trigger the `deploy` workflow that only lint because there isn't any tests on this project for now.

No `scripts/release.sh` changes needed because the flow is completely different here.
We pass from a script based to a gitflow based publish management.
